### PR TITLE
nit: fix minor typo in man page

### DIFF
--- a/wmctrl.1
+++ b/wmctrl.1
@@ -318,7 +318,7 @@ to use the currently active window for the action.
 
 .TP
 .I <WORKAROUND>
-There is only one work around currently implemeted. It is specified by
+There is only one work around currently implemented. It is specified by
 using the string
 .B DESKTOP_TITLES_INVALID_UTF8
 and it causes the printing of non-ASCII desktop tiles correctly when


### PR DESCRIPTION
I saw this typo while reading the docs and wanted to fix it.

While I was at it, I put this whole file through spellcheck and didn't find any other issues.